### PR TITLE
add <threadsafe> element to appengine-web.xml

### DIFF
--- a/src/main/g8/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/g8/src/main/webapp/WEB-INF/appengine-web.xml
@@ -2,6 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>$gae_app_name$</application>
   <version>$gae_app_version$</version>
+  <threadsafe>true</threadsafe>
   <sessions-enabled>$gae_sessions_enabled$</sessions-enabled>
   <system-properties>
     <property name="in.gae.j" value="true" />


### PR DESCRIPTION
`<threadsafe>` element is required from SDK version 1.6.5

http://googleappengine.blogspot.jp/2012/04/app-engine-165-released.html
https://developers.google.com/appengine/docs/java/config/appconfig#Using_Concurrent_Requests
